### PR TITLE
Implement a cli

### DIFF
--- a/cabal-build-info.cabal
+++ b/cabal-build-info.cabal
@@ -1,7 +1,9 @@
 cabal-version:      2.4
 name:               cabal-build-info
 version:            0.0.1.0
-synopsis:           Encoder and Decoder for Cabal's various json build artefacts.
+synopsis:
+  Encoder and Decoder for Cabal's various json build artefacts.
+
 description:
   Provides convenient encoder and decoder for Cabal's various json build artefacts.
 
@@ -16,17 +18,40 @@ extra-source-files:
   tests/resources/input/*.json
 
 category:           development, mit, library
-tested-with:  GHC==9.0.1, GHC==8.10.2, GHC==8.8.4
-
+tested-with:        GHC ==9.6.4
 
 library
-  exposed-modules:  Cabal.BuildInfo
-  build-depends:
-    , aeson  ^>=2.2.0.0
-    , base   >=4.12.0 && <4.19
-    , text   >=2.0 && <2.2
+  exposed-modules:
+    Cabal.Json.BuildInfo
+    Cabal.Json.Common
+    Cabal.Json.Plan
+    Cabal.Plan
+    Cabal.Target
 
+  build-depends:
+    , aeson              ^>=2.2.0.0
+    , aeson-combinators
+    , base               >=4.12.0   && <4.19
+    , containers
+    , text               >=2.0      && <2.2
+
+  ghc-options:      -Wall
   hs-source-dirs:   src
+  default-language: Haskell2010
+
+executable cabal-build-info
+  main-is:          Main.hs
+  hs-source-dirs:   exe
+  ghc-options:      -Wall
+  build-depends:
+    , base
+    , cabal-build-info
+    , containers
+    , directory
+    , filepath
+    , optparse-applicative
+    , text
+
   default-language: Haskell2010
 
 test-suite unit-tests
@@ -39,6 +64,7 @@ test-suite unit-tests
     , cabal-build-info
     , filepath
     , QuickCheck
+    , quickcheck-instances
     , tasty
     , tasty-golden
     , tasty-quickcheck

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,4 @@
+packages: ./
+
+package cabal-build-info
+    build-info: True

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -1,0 +1,115 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+
+import Cabal.Json.BuildInfo
+import Cabal.Json.Plan
+import Cabal.Plan
+import Cabal.Target (listTargets)
+import qualified Data.Maybe as Maybe
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+import Options.Applicative
+import System.Directory (getCurrentDirectory)
+import System.FilePath
+
+main :: IO ()
+main = do
+  theOpts <- execParser opts
+
+  planJsonLoc <- planJsonLocToFp $ optPlanJson theOpts
+  mPlanJson <- readCabalPlanJson planJsonLoc
+  case mPlanJson of
+    Left err -> error $ "Failed to parse `plan.json` found at " <> planJsonLoc <> " because: " <> err
+    Right planJson -> do
+      case optCommand theOpts of
+        ListTargets -> mapM_ T.putStrLn (listTargets planJson)
+        ShowCompilationOptions target -> case findUnitByTarget target planJson of
+          Nothing -> error "No such unit was found"
+          Just unitOrPkg -> do
+            let Just biFp = case unitOrPkg of
+                  InstalledUnit node -> unitBuildInfo node
+                  InstalledPackage node -> packageBuildInfo node
+                  _ -> error "unexpected preexisting"
+
+                pkgName = case unitOrPkg of
+                  InstalledUnit node -> unitPkgName node
+                  InstalledPackage node -> packagePkgName node
+                  _ -> error "unexpected preexisting"
+
+            decodeBuildInfoFile biFp >>= \case
+              Left err -> error $ "Failed to parse build-info at " <> biFp <> ": " <> show err
+              Right bi ->
+                case findComponent pkgName target bi of
+                  Nothing -> error "No such component"
+                  Just compInfo -> do
+                    mapM_ T.putStrLn (componentCompilerArgs compInfo)
+ where
+  opts =
+    info
+      (optionParser <**> helper)
+      ( fullDesc
+          <> progDesc "Parse various build artefacts of cabal"
+          <> header "cabal-build-info: parse and query for information found in cabal's build artefacts"
+      )
+
+findComponent :: T.Text -> Target -> BuildInfo -> Maybe ComponentInfo
+findComponent pkgName target bi =
+  Maybe.listToMaybe
+    [ compInfo
+    | compInfo <- components bi
+    , T.intercalate ":" [pkgName, compName (componentName compInfo)] == target
+    ]
+ where
+  compName name
+    | name == "lib" = "lib:" <> pkgName
+    | otherwise = name
+
+data PlanJsonLoc
+  = InDirectory FilePath
+  | InBuildDir FilePath
+  | InExact FilePath
+  deriving (Show, Eq, Ord)
+
+planJsonLocToFp :: Maybe PlanJsonLoc -> IO FilePath
+planJsonLocToFp Nothing = do
+  cwd <- getCurrentDirectory
+  pure $ cwd </> "dist-newstyle" </> "cache" </> "plan.json"
+planJsonLocToFp (Just loc) = pure $ case loc of
+  InDirectory fp -> fp </> "dist-newstyle" </> "cache" </> "plan.json"
+  InBuildDir fp -> fp </> "cache" </> "plan.json"
+  InExact fp -> fp
+
+data Options = Options
+  { optPlanJson :: Maybe PlanJsonLoc
+  , optCommand :: Command
+  }
+
+data Command
+  = ListTargets
+  | ShowCompilationOptions Target
+
+optionParser :: Parser Options
+optionParser =
+  Options
+    <$> optional
+      ( InDirectory
+          <$> strOption (long "work-dir" <> short 'w' <> metavar "FILE")
+            <|> InBuildDir
+          <$> strOption (long "builddir" <> metavar "FILE")
+            <|> InExact
+          <$> strOption (long "plan-json" <> metavar "FILE")
+      )
+    <*> ( subparser $
+            mconcat
+              [ command "list-targets" (info (pure ListTargets) (progDesc "List targets of the cabal project"))
+              , command
+                  "build-info"
+                  ( info showCompilationOptions (progDesc "Find compilation options for this target")
+                  )
+              ]
+        )
+ where
+  showCompilationOptions =
+    ShowCompilationOptions
+      <$> argument str (metavar "TARGET")

--- a/src/Cabal/Json/BuildInfo.hs
+++ b/src/Cabal/Json/BuildInfo.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RecordWildCards #-}
 
-module Cabal.BuildInfo (
+module Cabal.Json.BuildInfo (
   decodeBuildInfoFile,
   BuildInfo (..),
   CompilerInfo (..),
@@ -13,27 +13,17 @@ module Cabal.BuildInfo (
 where
 
 import Data.Aeson
-import qualified Data.Aeson.Encoding as A
-import Data.Aeson.Types
 import qualified Data.Text as T
 import Data.Version
 import GHC.Generics
-import Text.ParserCombinators.ReadP
+
+import Cabal.Json.Common
 
 decodeBuildInfoFile :: FilePath -> IO (Either String BuildInfo)
 decodeBuildInfoFile = eitherDecodeFileStrict
 
 decodeComponentInfoFile :: FilePath -> IO (Either String ComponentInfo)
 decodeComponentInfoFile = eitherDecodeFileStrict
-
-data CompilerId = CompilerId
-  { compilerName :: T.Text
-  , compilerVersion :: Version
-  }
-  deriving (Show, Eq, Ord)
-
-prettyCompilerId :: CompilerId -> T.Text
-prettyCompilerId CompilerId{..} = compilerName <> T.pack "-" <> T.pack (showVersion compilerVersion)
 
 data BuildInfo = BuildInfo
   { cabalLibVersion :: Version
@@ -50,57 +40,21 @@ data CompilerInfo = CompilerInfo
   deriving (Generic, Show, Eq)
 
 data ComponentInfo = ComponentInfo
-  { componentType :: String
-  , componentName :: String
-  , componentUnitId :: String
-  , componentCompilerArgs :: [String]
-  , componentModules :: [String]
-  , componentSrcFiles :: [FilePath]
-  , componentHsSrcDirs :: [FilePath]
-  , componentSrcDir :: FilePath
-  , componentCabalFile :: Maybe FilePath
+  { componentType ::   T.Text
+  , componentName ::   T.Text
+  , componentUnitId :: T.Text
+  , componentCompilerArgs :: [T.Text]
+  , componentModules :: [T.Text]
+  , componentSrcFiles :: [T.Text]
+  , componentHsSrcDirs :: [T.Text]
+  , componentSrcDir :: T.Text
+  , componentCabalFile :: Maybe T.Text
   }
   deriving (Generic, Show, Eq)
 
 -- ----------------------------------------------
 -- JSON instances
 -- ----------------------------------------------
-
-instance ToJSON CompilerId where
-  toJSON = String . prettyCompilerId
-  toEncoding = A.text . prettyCompilerId
-
-instance FromJSON CompilerId where
-  parseJSON (String v) = case parseCompilerId v of
-    Just compId -> pure compId
-    Nothing ->
-      prependFailure
-        "parsing CompilerId failed, "
-        (typeMismatch "Version" (String v))
-   where
-    parseInnerVersion :: T.Text -> Maybe Version
-    parseInnerVersion s =
-      case reverse $ readP_to_S parseVersion (T.unpack s) of
-        (version, "") : _ -> Just version
-        _ -> Nothing
-
-    parseCompilerId v = do
-      let (namePart, versionStr) = T.breakOnEnd (T.pack "-") v
-      version <- parseInnerVersion versionStr
-      name <- T.stripSuffix (T.pack "-") namePart
-      pure
-        CompilerId
-          { compilerName = name
-          , compilerVersion = version
-          }
-
-  -- We do not expect a non-String value here.
-  -- We could use empty to fail, but typeMismatch
-  -- gives a much more informative error message.
-  parseJSON invalid =
-    prependFailure
-      "parsing CompilerId failed, "
-      (typeMismatch "String" invalid)
 
 instance ToJSON BuildInfo where
   toJSON = genericToJSON snakeCaseOptions

--- a/src/Cabal/Json/Common.hs
+++ b/src/Cabal/Json/Common.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+
+module Cabal.Json.Common where
+
+import qualified Data.Aeson.Encoding as A
+import Data.Aeson.Types
+import qualified Data.Text as T
+import Data.Version
+import Text.ParserCombinators.ReadP
+import Data.Data
+
+data CompilerId = CompilerId
+  { compilerName :: T.Text
+  , compilerVersion :: Version
+  }
+  deriving (Show, Eq, Ord, Data, Typeable)
+
+prettyCompilerId :: CompilerId -> T.Text
+prettyCompilerId CompilerId{..} = compilerName <> T.pack "-" <> T.pack (showVersion compilerVersion)
+
+instance ToJSON CompilerId where
+  toJSON = String . prettyCompilerId
+  toEncoding = A.text . prettyCompilerId
+
+instance FromJSON CompilerId where
+  parseJSON (String v) = case parseCompilerId v of
+    Just compId -> pure compId
+    Nothing ->
+      prependFailure
+        "parsing CompilerId failed, "
+        (typeMismatch "Version" (String v))
+   where
+    parseInnerVersion :: T.Text -> Maybe Version
+    parseInnerVersion s =
+      case reverse $ readP_to_S parseVersion (T.unpack s) of
+        (version, "") : _ -> Just version
+        _ -> Nothing
+
+    parseCompilerId v = do
+      let (namePart, versionStr) = T.breakOnEnd (T.pack "-") v
+      version <- parseInnerVersion versionStr
+      name <- T.stripSuffix (T.pack "-") namePart
+      pure
+        CompilerId
+          { compilerName = name
+          , compilerVersion = version
+          }
+
+  -- We do not expect a non-String value here.
+  -- We could use empty to fail, but typeMismatch
+  -- gives a much more informative error message.
+  parseJSON invalid =
+    prependFailure
+      "parsing CompilerId failed, "
+      (typeMismatch "String" invalid)

--- a/src/Cabal/Json/Plan.hs
+++ b/src/Cabal/Json/Plan.hs
@@ -1,0 +1,224 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveFoldable #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+
+module Cabal.Json.Plan where
+
+import Cabal.Json.Common
+import Data.Aeson
+import qualified Data.Aeson as Aeson
+import Data.Map (Map)
+import qualified Data.Text as T
+import Data.Version
+import GHC.Generics
+import Data.Data
+
+type UnitId = T.Text
+
+type PackageName = T.Text
+
+readCabalPlanJson :: FilePath -> IO (Either String (CabalPlan UnitId))
+readCabalPlanJson fp = Aeson.eitherDecodeFileStrict' fp
+
+data CabalPlan key = CabalPlan
+  { planCabalVersion :: Version
+  , planCabalLibVersion :: Version
+  , planCompilerId :: CompilerId
+  , planOs :: T.Text
+  , planArch :: T.Text
+  , planInstallPlan :: [InstallPlanNode key]
+  }
+  deriving (Show, Ord, Eq, Functor, Foldable, Traversable, Generic, Data, Typeable)
+
+data InstallPlanNode key where
+  InstalledUnit :: InstalledUnitNode key -> InstallPlanNode key
+  InstalledPackage :: InstalledPackageNode key -> InstallPlanNode key
+  Existing :: PreExistingNode key -> InstallPlanNode key
+  deriving (Show, Ord, Eq, Functor, Foldable, Traversable, Generic, Data, Typeable)
+
+data PreExistingNode key = PreExistingNode
+  { preExistingType :: T.Text
+  , preExistingId :: T.Text
+  , preExistingPkgName :: T.Text
+  , preExistingPkgVersion :: T.Text
+  , preExistingDepends :: [key]
+  }
+  deriving (Show, Ord, Eq, Functor, Foldable, Traversable, Generic, Data, Typeable)
+
+data InstalledUnitNode key = InstalledUnitNode
+  { unitType :: T.Text
+  , unitId :: key
+  , unitPkgName :: T.Text
+  , unitPkgVersion :: Version
+  , unitFlags :: Map T.Text Bool
+  , unitStyle :: T.Text
+  , unitPkgSrc :: PackageSource
+  , unitPkgCabalSha256 :: Maybe T.Text
+  , unitPkgSrcSha256 :: Maybe T.Text
+  , unitBuildInfo :: Maybe FilePath
+  , unitDistDir :: Maybe FilePath
+  , unitDepends :: [key]
+  , unitExeDepends :: [key]
+  , unitBinFile :: Maybe FilePath
+  , unitComponentName :: T.Text
+  }
+  deriving (Show, Ord, Eq, Functor, Foldable, Traversable, Generic, Data, Typeable)
+
+data InstalledPackageNode key = InstalledPackageNode
+  { packageType :: T.Text
+  , packageId :: key
+  , packagePkgName :: T.Text
+  , packagePkgVersion :: Version
+  , packageFlags :: Map T.Text Bool
+  , packageStyle :: T.Text
+  , packagePkgSrc :: PackageSource
+  , packagePkgCabalSha256 :: Maybe T.Text
+  , packagePkgSrcSha256 :: Maybe T.Text
+  , packageBuildInfo :: Maybe FilePath
+  , packageDistDir :: Maybe FilePath
+  , packageComponents :: Map Component (PackageDepends key)
+  }
+  deriving (Show, Ord, Eq, Functor, Foldable, Traversable, Generic, Data, Typeable)
+
+type Component = T.Text
+
+type ComponentId = T.Text
+
+data PackageDepends key = PackageDepends
+  { packageDependsDepends :: [key]
+  , packageDependsExeDepends :: [T.Text]
+  , packageDependsBinFile :: Maybe FilePath
+  }
+  deriving (Show, Ord, Eq, Functor, Foldable, Traversable, Generic, Data, Typeable)
+
+data PackageSource
+  = LocalSource LocalPackageSource
+  | -- | UriSource RepoSourceUri
+    TarSource RepoSourceTar
+  deriving (Show, Ord, Eq, Generic, Data, Typeable)
+
+data LocalPackageSource = LocalPackageSource
+  { localPackageSourcePath :: FilePath
+  }
+  deriving (Show, Ord, Eq, Generic, Data, Typeable)
+
+data RepoSourceUri = RepoSourceUri
+  { repoSourceUri :: T.Text
+  }
+  deriving (Show, Ord, Eq, Generic, Data, Typeable)
+
+data RepoSourceTar = RepoSourceTar
+  { repoSourceTarUri :: T.Text
+  , repoSourceTarType :: T.Text
+  }
+  deriving (Show, Ord, Eq, Generic, Data, Typeable)
+
+instance (ToJSON key) => ToJSON (CabalPlan key) where
+  toJSON = genericToJSON cabalPlanOptions
+  toEncoding = genericToEncoding cabalPlanOptions
+
+instance (FromJSON key) => FromJSON (CabalPlan key) where
+  parseJSON = genericParseJSON cabalPlanOptions
+
+instance (ToJSON key) => ToJSON (InstallPlanNode key) where
+  toJSON = genericToJSON installPlanNodeOptions
+  toEncoding = genericToEncoding installPlanNodeOptions
+
+instance (FromJSON key) => FromJSON (InstallPlanNode key) where
+  parseJSON = genericParseJSON installPlanNodeOptions
+
+instance (ToJSON key) => ToJSON (PreExistingNode key) where
+  toJSON = genericToJSON preExistingNodeOptions
+  toEncoding = genericToEncoding preExistingNodeOptions
+
+instance (FromJSON key) => FromJSON (PreExistingNode key) where
+  parseJSON = genericParseJSON preExistingNodeOptions
+
+instance (ToJSON key) => ToJSON (InstalledUnitNode key) where
+  toJSON = genericToJSON installedUnitNodeOptions
+  toEncoding = genericToEncoding installedUnitNodeOptions
+
+instance (FromJSON key) => FromJSON (InstalledUnitNode key) where
+  parseJSON = genericParseJSON installedUnitNodeOptions
+
+instance (ToJSON key) => ToJSON (InstalledPackageNode key) where
+  toJSON = genericToJSON installedPackageNodeOptions
+  toEncoding = genericToEncoding installedPackageNodeOptions
+
+instance (FromJSON key) => FromJSON (InstalledPackageNode key) where
+  parseJSON = genericParseJSON installedPackageNodeOptions
+
+instance (ToJSON key) => ToJSON (PackageDepends key) where
+  toJSON = genericToJSON packageDependsOptions
+  toEncoding = genericToEncoding packageDependsOptions
+
+instance (FromJSON key) => FromJSON (PackageDepends key) where
+  parseJSON = genericParseJSON packageDependsOptions
+
+instance ToJSON PackageSource where
+  toJSON (LocalSource (LocalPackageSource fp)) =
+    Aeson.object
+      [ "type" .= ("local" :: T.Text)
+      , "path" .= T.pack fp
+      ]
+  toJSON (TarSource repoSourceTar) =
+    Aeson.object
+      [ "type" .= ("repo-tar" :: T.Text)
+      , "repo" .= repoSourceTar
+      ]
+  toEncoding (LocalSource (LocalPackageSource fp)) =
+    Aeson.pairs $
+      "type" .= ("local" :: T.Text)
+        <> "path" .= T.pack fp
+  toEncoding (TarSource repoSourceTar) =
+    Aeson.pairs $
+      "type" .= ("repo-tar" :: T.Text)
+        <> "repo" .= repoSourceTar
+
+instance FromJSON PackageSource where
+  parseJSON = withObject "PackageSource" $ \o -> do
+    ty :: T.Text <- o .: "type"
+    case ty of
+      "local" -> LocalSource <$> (LocalPackageSource <$> o .: "path")
+      "repo-tar" -> TarSource <$> (o .: "repo")
+      _ -> undefined
+
+instance ToJSON RepoSourceTar where
+  toJSON = genericToJSON repoSourceTarOptions
+  toEncoding = genericToEncoding repoSourceTarOptions
+
+instance FromJSON RepoSourceTar where
+  parseJSON = genericParseJSON repoSourceTarOptions
+
+installPlanNodeOptions :: Options
+installPlanNodeOptions = defaultOptions{sumEncoding = UntaggedValue}
+
+cabalPlanOptions :: Options
+cabalPlanOptions = defaultOptionsWithPrefix "plan"
+
+repoSourceTarOptions :: Options
+repoSourceTarOptions = defaultOptionsWithPrefix "repoSourceTar"
+
+installedPackageNodeOptions :: Options
+installedPackageNodeOptions = defaultOptionsWithPrefix "package"
+
+preExistingNodeOptions :: Options
+preExistingNodeOptions = defaultOptionsWithPrefix "preExisting"
+
+installedUnitNodeOptions :: Options
+installedUnitNodeOptions = defaultOptionsWithPrefix "unit"
+
+packageDependsOptions :: Options
+packageDependsOptions = defaultOptionsWithPrefix "packageDepends"
+
+defaultOptionsWithPrefix :: T.Text -> Options
+defaultOptionsWithPrefix t = defaultOptions{fieldLabelModifier = drop (prefix + 1) . camelTo2 '-'}
+ where
+  prefix = length (camelTo2 '-' $ T.unpack t)

--- a/src/Cabal/Plan.hs
+++ b/src/Cabal/Plan.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Cabal.Plan where
+
+import Cabal.Json.Plan
+import qualified Data.Maybe as Maybe
+import qualified Data.Text as T
+
+type Target = T.Text
+
+findUnitByTarget :: T.Text -> CabalPlan UnitId -> Maybe (InstallPlanNode UnitId)
+findUnitByTarget target = findUnitBy
+  (\unit -> prettyTargetName unit == target)
+  (\pkg -> packagePkgName pkg == pkgName)
+  where
+    (pkgName:_:_) = T.splitOn ":" target
+    prettyTargetName node
+      | unitComponentName node == "lib" = unitPkgName node <> ":lib:" <> unitPkgName node
+      | otherwise = unitPkgName node <> ":" <> unitComponentName node
+
+findUnitBy ::
+  (InstalledUnitNode UnitId -> Bool) ->
+  (InstalledPackageNode UnitId -> Bool) ->
+  CabalPlan UnitId ->
+  Maybe (InstallPlanNode UnitId)
+findUnitBy pUnit pPkg planJson = do
+  let plan = planInstallPlan planJson
+  Maybe.listToMaybe $ filter go plan
+ where
+  go (InstalledUnit node) = pUnit node
+  go (InstalledPackage node) = pPkg node
+  go _ = False -- We don't support these nodes right now

--- a/src/Cabal/Target.hs
+++ b/src/Cabal/Target.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Cabal.Target where
+
+import Cabal.Json.Plan
+import qualified Data.Map as Map
+import qualified Data.Text as T
+
+listTargets :: CabalPlan UnitId -> [T.Text]
+listTargets cplan =
+  let
+    installPlan = planInstallPlan cplan
+   in
+    flip concatMap installPlan $ \case
+      InstalledUnit unitNode -> do
+        "local" <- pure $ unitStyle unitNode
+        pure $ prettyTarget (unitPkgName unitNode) (unitComponentName unitNode)
+      InstalledPackage pkgNode -> do
+        "local" <- pure $ packageStyle pkgNode
+        [ prettyTarget (packagePkgName pkgNode) componentName
+          | componentName <- Map.keys (packageComponents pkgNode)
+          ]
+      Existing _ -> mempty
+
+  where
+    prettyTarget package component
+      | component == "lib" = package <> ":lib:" <> package
+      | otherwise = package <> ":" <> component

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -5,11 +5,12 @@
 
 module Main where
 
-import Cabal.BuildInfo
+import Cabal.Json.BuildInfo
 import Data.Aeson
 import Data.Aeson.Encode.Pretty (encodePretty)
 import Data.Proxy
 import System.FilePath
+import Test.QuickCheck.Instances.Text ()
 import Test.Tasty
 import Test.Tasty.Golden
 import Test.Tasty.QuickCheck as QC


### PR DESCRIPTION
Additionally implements a plan.json parser (untested) and some POC functions, such as `list-targets` and `build-info`, which prints the compilation arguments for components, given a target string of the form `pkg:comptype:compname`.